### PR TITLE
self-chatting implementation

### DIFF
--- a/src/handlers/directChats.ts
+++ b/src/handlers/directChats.ts
@@ -64,19 +64,25 @@ export function parseDirectChats(
       if (!result[user]) {
         result[user] = {}
       }
-
-      // Iterate over all other users in the same chat
-      for (const otherUser of users) {
-        // Skip the current user
-        if (otherUser !== user) {
-          // If the other user is not already in the result, add them
-          if (!result[user][otherUser]) {
-            result[user][otherUser] = []
-          }
-
-          // Add the current chat to the list of direct chats between the users
-          if (!result[user][otherUser].includes(chat)) {
-            result[user][otherUser].push(chat)
+      // If only one user in chat (self chatting), add him
+      if (users.length == 1) {
+        result[user][user] = []
+        if (!result[user][user].includes(chat)) {
+          result[user][user].push(chat)
+        }
+      } else {
+        // Iterate over all other users in the same chat
+        for (const otherUser of users) {
+          // Skip the current user
+          if (otherUser !== user) {
+            // If the other user is not already in the result, add them
+            if (!result[user][otherUser]) {
+              result[user][otherUser] = []
+            }
+            // Add the current chat to the list of direct chats between the users
+            if (!result[user][otherUser].includes(chat)) {
+              result[user][otherUser].push(chat)
+            }
           }
         }
       }

--- a/src/handlers/rooms.ts
+++ b/src/handlers/rooms.ts
@@ -34,6 +34,8 @@ export const enum RcRoomTypes {
 export type RcRoom = {
   _id: string
   t: RcRoomTypes
+  usersCount?: number
+  lastMessage?: {[key: string]: {[key: string]: string}}
   uids?: string[]
   usernames?: string[]
   name?: string
@@ -91,6 +93,9 @@ export function mapRoom(rcRoom: RcRoom): MatrixRoom {
 
   switch (rcRoom.t) {
     case RcRoomTypes.direct:
+      if (rcRoom.usersCount == 1) {
+        rcRoom.lastMessage && (room.name = rcRoom.lastMessage.u.name)
+      }
       room.is_direct = true
       room.preset = MatrixRoomPresets.trusted
       break
@@ -130,7 +135,7 @@ export function mapRoom(rcRoom: RcRoom): MatrixRoom {
 export function getCreator(rcRoom: RcRoom): string {
   if (rcRoom.u && rcRoom.u._id) {
     return rcRoom.u._id
-  } else if (rcRoom.uids && rcRoom.uids.length > 1) {
+  } else if (rcRoom.uids && rcRoom.uids.length >= 1) {
     return rcRoom.uids[0]
   } else {
     log.warn(


### PR DESCRIPTION
Hi Team Vertigado!

Nice work going on here, 
I tried your last fix for Direct Chat and it works well for me.
It just doesn't handle a case i've encountered.

Specific Case:

When using Rocket Chat people often open a chat with themself as a memo chat.

What happens with actual main branch:

When we want to get Branch's creator it finds nothing and therefore creates it with admin bot and then add the user in Room. Furthermore the Room's name is name of admin bot.
It also leads to problems with Direct Chat implementation.
Problem is in 'getCreator' function when we say 'rcRoom.uids.length > 1' because uids.length is 1.

I also considered that in a self chatting room the room's name shoud be that of last message author.
And I also implemented a special case for Direct Chat to handle it.

I Hope it will please you!

Don't hesitate to make comments and if you think I should change something in the implementation.

Have a good day!