### PR TITLE
feat: ease usage of a another matrix username

### DIFF
--- a/src/entity/IdMapping.ts
+++ b/src/entity/IdMapping.ts
@@ -8,6 +8,9 @@ export class IdMapping {
   @Column()
   matrixId?: string // Matrix ID of the entity
 
+  @Column({ nullable: true })
+  rcUsername?: string // rcUsername of the entity
+
   @Column('integer')
   type!: number // Type of the entity; 0 = user, 1 = room, 2 = message
 

--- a/src/handlers/users.test.ts
+++ b/src/handlers/users.test.ts
@@ -102,9 +102,10 @@ test('users are excluded', () => {
 })
 
 test('creating mapping', async () => {
-  await expect(createMapping(rcUser._id, matrixUser)).resolves.toBe(undefined)
+  await expect(createMapping(rcUser, matrixUser)).resolves.toBe(undefined)
   expect(mockedStorage.save).toHaveBeenCalledWith({
     rcId: rcUser._id,
+    rcUsername: "testuser",
     matrixId: matrixUser.user_id,
     type: entities[Entity.Users].mappingType,
     accessToken: matrixUser.access_token,

--- a/src/handlers/users.ts
+++ b/src/handlers/users.ts
@@ -130,12 +130,13 @@ export function userIsExcluded(rcUser: RcUser): boolean {
  * @param matrixUser The Matrix user object, including ID and access token
  */
 export async function createMapping(
-  rcId: string,
+  rcUser: RcUser,
   matrixUser: MatrixUser
 ): Promise<void> {
   const mapping = new IdMapping()
-  mapping.rcId = rcId
+  mapping.rcId = rcUser._id
   mapping.matrixId = matrixUser.user_id
+  mapping.rcUsername = rcUser.username
   mapping.type = entities[Entity.Users].mappingType
   mapping.accessToken = matrixUser.access_token
 
@@ -167,7 +168,7 @@ export async function createUser(rcUser: RcUser): Promise<MatrixUser> {
  * @param rcUser The RC user to handle
  */
 export async function handle(rcUser: RcUser): Promise<void> {
-  log.info(`Parsing user: ${rcUser.name}: ${rcUser._id}`)
+  log.info(`Parsing user: ${rcUser.name}: ${rcUser._id} ${rcUser.username}`)
 
   const matrixId = await getUserId(rcUser._id)
   if (matrixId) {
@@ -177,10 +178,10 @@ export async function handle(rcUser: RcUser): Promise<void> {
       log.info(
         `User ${rcUser.username} is defined as admin in ENV, mapping as such`
       )
-      await createMapping(rcUser._id, adminAccessToken as unknown as MatrixUser)
+      await createMapping(rcUser, adminAccessToken as unknown as MatrixUser)
     } else if (!userIsExcluded(rcUser)) {
       const matrixUser = await createUser(rcUser)
-      await createMapping(rcUser._id, matrixUser)
+      await createMapping(rcUser, matrixUser)
     }
   }
 }

--- a/src/helpers/storage.ts
+++ b/src/helpers/storage.ts
@@ -58,14 +58,14 @@ export function getMappingByMatrixId(
 
 /**
  * Search for a user IdMapping by its name
- * @param username The Matrix or Rocket.Chat username to look up
+ * @param username The Rocket.Chat username to look up
  * @returns One found IdMapping or null
  */
 export function getUserMappingByName(
   username: string
 ): Promise<IdMapping | null> {
   return AppDataSource.manager.findOneBy(IdMapping, {
-    matrixId: ILike(`@${username.toLowerCase()}:%`),
+    rcUsername: ILike(`${username.toLowerCase()}`),
     type: entities[Entity.Users].mappingType,
   })
 }


### PR DESCRIPTION
relates to: https://github.com/verdigado/rocketchat2matrix/issues/5

then I have a file like this:

```
src/helpers/ih.ts
```
```
/*àçéèêëîïñô*/
let latin_map = new Map<string, string>([
  ["à", "a"],
  ["ç", "c"],
  ["é", "e"],
  ["è", "e"],
  ["ë", "e"],
  ["ê", "e"],
  ["î", "i"],
  ["ï", "i"],
  ["ñ", "n"],
  ["ô", "o"],
]);

function latinise(s: string): string{
  return s.replace(/[^A-Za-z0-9\[\] ]/g,function(char){return latin_map.get(char)||char})
};

export function customConvertion(u: string): string{
  return latinise(u.replace(/é/,'_')).replace(/@toot|@bob|@rr|@toto/,'_').replace(/\.io|\.org|\.fr|\.com|\.net|@.*|[^\.a-z0-9_-]/g,'');
};
```

and then in users.ts, I do (`liiibre` is the name of my sso):
```
...
import { axios } from '../helpers/synapse'
import { customConvertion } from '../helpers/ih'

export type RcUser = {
  _id: string
  username: string
  name: string
  services: {
    liiibre: {
      preferred_username: string
    }
  }
  roles: string[]
  __rooms: string[]
}

export type MatrixUser = {
  user_id: string
  username: string
  displayname: string
  password: string
  admin: boolean
  nonce?: string
  mac?: string
  access_token?: string
}

export type AccessToken = {
  access_token: string
  device_id: string
  home_server: string
  user_id: string
}

export function mapUser(rcUser: RcUser): MatrixUser {
  if (!rcUser.services.liiibre.preferred_username) {
    log.debug(`${rcUser.name}  ${rcUser.username} ${rcUser.services.liiibre.preferred_username} has empty username`)
  }

  return {
    user_id: '',
    username: customConvertion(rcUser.services.liiibre.preferred_username),
    displayname: rcUser.name,
...
```

The rest, I don't know how to PR it, but the part of the PR can hopefully helps!
(Sorry, I'm no ts expert :/ )