### PR TITLE
Use Rocket.Chat room `fname` instead of `name` as Matrix room name when possible

### DIFF
--- a/src/handlers/rooms.ts
+++ b/src/handlers/rooms.ts
@@ -87,7 +87,7 @@ export function mapRoom(rcRoom: RcRoom): MatrixRoom {
       'm.federate': false,
     },
   }
-  rcRoom.name && (room.name = rcRoom.name)
+  room.name = rcRoom.fname ? rcRoom.fname : rcRoom.name
   rcRoom.name && (room.room_alias_name = rcRoom.name)
   rcRoom.description && (room.topic = rcRoom.description)
 


### PR DESCRIPTION
It looks like `fname` is a human-readable name, and `name` is an automatically generated slug.