### PR TITLE
Implement ordered concurrency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
+        "@supercharge/promise-pool": "^3.2.0",
         "@types/showdown": "^2.0.6",
         "axios": "^1.7.2",
         "dotenv": "^16.4.5",
@@ -1339,6 +1340,15 @@
     "node_modules/@sqltools/formatter": {
       "version": "1.2.5",
       "license": "MIT"
+    },
+    "node_modules/@supercharge/promise-pool": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@supercharge/promise-pool/-/promise-pool-3.2.0.tgz",
+      "integrity": "sha512-pj0cAALblTZBPtMltWOlZTQSLT07jIaFNeM8TWoJD1cQMgDB9mcMlVMoetiB35OzNJpqQ2b+QEtwiR9f20mADg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
+    "@supercharge/promise-pool": "^3.2.0",
     "@types/showdown": "^2.0.6",
     "axios": "^1.7.2",
     "dotenv": "^16.4.5",

--- a/src/app.ts
+++ b/src/app.ts
@@ -31,28 +31,34 @@ async function loadRcExport(entity: Entity) {
   const rl = new lineByLine(`./inputs/${entities[entity].filename}`)
 
   let line: false | Buffer
-  while ((line = rl.next())) {
-    const item = JSON.parse(line.toString())
-    switch (entity) {
-      case Entity.Users:
+  switch (entity) {
+    case Entity.Users:
+      while ((line = rl.next())) {
+        const item = JSON.parse(line.toString())
         userQueue.push(item)
-        break
+      }
+      break
 
-      case Entity.Rooms:
+    case Entity.Rooms:
+      while ((line = rl.next())) {
+        const item = JSON.parse(line.toString())
         roomQueue.push(item)
-        break
+      }
+      break
 
-      case Entity.Messages:
+    case Entity.Messages:
+      while ((line = rl.next())) {
+        const item = JSON.parse(line.toString())
         if (messagesPerRoom.has(item.rid)) {
           messagesPerRoom.get(item.rid)?.push(item)
         } else {
           messagesPerRoom.set(item.rid, [item])
         }
-        break
+      }
+      break
 
-      default:
-        throw new Error(`Unhandled Entity: ${entity}`)
-    }
+    default:
+      throw new Error(`Unhandled Entity: ${entity}`)
   }
 
   await PromisePool.withConcurrency(concurrency)

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,8 +10,8 @@ import { handleDirectChats } from './handlers/directChats'
 import { handleRoomMemberships } from './handlers/handleRoomMemberships'
 import { handle as handleMessage, RcMessage } from './handlers/messages'
 import { handlePinnedMessages } from './handlers/pinnedMessages'
-import { handle as handleRoom } from './handlers/rooms'
-import { handle as handleUser } from './handlers/users'
+import { handle as handleRoom, RcRoom } from './handlers/rooms'
+import { handle as handleUser, RcUser } from './handlers/users'
 import log from './helpers/logger'
 import { initStorage } from './helpers/storage'
 import { whoami } from './helpers/synapse'
@@ -24,8 +24,8 @@ log.info('rocketchat2matrix starts.')
  */
 async function loadRcExport(entity: Entity) {
   const concurrency = parseInt(process.env.CONCURRENCY_LIMIT || '50')
-  const user_queue = []
-  const room_queue = []
+  const user_queue: RcUser[] = []
+  const room_queue: RcRoom[] = []
   const messages_per_room: Map<string, RcMessage[]> = new Map()
 
   const rl = new lineByLine(`./inputs/${entities[entity].filename}`)


### PR DESCRIPTION
As discussed in https://github.com/verdigado/rocketchat2matrix/issues/22 and https://github.com/verdigado/rocketchat2matrix/issues/3#issuecomment-2250766562:
Concurrency on message handling broke the server-side ordering, because the server orders the messages in the sequence they arrived in.
To add a bit of concurrency anyways, the idea is to group messages per room and handle the messages in each room sequentially, while handling the rooms in parallel. Of course you would need a very large number of rooms for this to make a great difference.

To note that I am new to typescript...